### PR TITLE
Calendar zoom

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## v2018.01.11
+
+[screenshot][screenshot-2018-01-11] | [demo permalink][demo-2018-01-11]
+
+- Add calendar metaphor for a zoomable 2D representation
+
+[screenshot-2018-01-11]:https://user-images.githubusercontent.com/116838/34836478-9ed6755e-f6bd-11e7-8895-353dfdfbc2cc.gif
+[demo-2018-01-11]:http://btrdb-viz-2018-01-11.surge.sh
+
 ## v2018.01.08
 
 [screenshot][screenshot-2018-01-08] | [demo permalink][demo-2018-01-08]

--- a/src/Demo.js
+++ b/src/Demo.js
@@ -10,7 +10,7 @@ export default function() {
         <header>
           <img src={logo} className="Demo-logo" alt="PingThings" />
         </header>
-        <div className="Demo-version">{"BTrDB Viz v2018.01.08"}</div>
+        <div className="Demo-version">{"BTrDB Viz v2018.01.11"}</div>
         <div className="Demo-notes">
           <p>
             Zooming into a BTrDB tree is achieved by descending its branches, so
@@ -22,7 +22,7 @@ export default function() {
           </ul>
           <h3>Changes</h3>
           <ul>
-            <li>Show dates</li>
+            <li>Show calendar metaphor</li>
           </ul>
           <h3>Next</h3>
           <ul>

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -317,7 +317,7 @@ class Viz extends Component {
   };
   drawCalendarCell = (ctx, level, cell) => {
     const s = this.state.calCellSize;
-    const len = 5;
+    const len = 4;
     ctx.save();
     ctx.beginPath();
     ctx.moveTo(0, 0);
@@ -352,6 +352,7 @@ class Viz extends Component {
     ctx.font = "10px sans-serif";
     ctx.textBaseline = "top";
     ctx.textAlign = "left";
+    const pad = { left: 5, top: 4 };
     const { calTimeK, calKX, calKRow, calRowY } = this.ds;
     if (level === 0) {
       const drawTick = (t, color, title) => {
@@ -365,7 +366,7 @@ class Viz extends Component {
         ctx.stroke();
         let y = calRowY(row);
         for (let text of title.split("\n")) {
-          ctx.fillText(text, x + 5, y + 2);
+          ctx.fillText(text, x + pad.left, y + pad.top);
           y += 12;
         }
       };
@@ -385,7 +386,7 @@ class Viz extends Component {
       ctx.stroke();
       let y = calRowY(row);
       for (let text of title.split("\n")) {
-        ctx.fillText(text, x + 5, y + 2);
+        ctx.fillText(text, x + pad.left, y + pad.top);
         y += 12;
       }
     };
@@ -505,7 +506,9 @@ class Viz extends Component {
     // outline child
     ctx.save();
     transformToChild();
-    ctx.strokeStyle = d3interpolate.interpolate(gridColor, "#555")(highlightT);
+    ctx.strokeStyle = d3interpolate.interpolate("rgba(0,0,0,0)", "#555")(
+      highlightT
+    );
     ctx.strokeRect(0, 0, calW, calW);
     ctx.restore();
 

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -104,7 +104,7 @@ class Viz extends Component {
       dipTime
     };
   };
-  drawCell = (ctx, level, cell) => {
+  drawTreeCell = (ctx, level, cell) => {
     const { cellH, cellW, path } = this.state;
     const child = path[level + 1];
     ctx.globalAlpha = child === cell ? 1 : 0.1;
@@ -115,7 +115,7 @@ class Viz extends Component {
       ctx.fillRect(0, 0, cellW, cellH);
     }
   };
-  drawNode = (ctx, level) => {
+  drawTreeNode = (ctx, level) => {
     const { numCells, cellW, cellH, path, levelOffset, pathAnim } = this.state;
     const { cellX, cellY, timeX, dipTime } = this.ds;
 
@@ -192,7 +192,7 @@ class Viz extends Component {
     if (t === 1) {
       ctx.save();
       for (let cell = 0; cell < numCells; cell++) {
-        this.drawCell(ctx, level, cell);
+        this.drawTreeCell(ctx, level, cell);
         ctx.translate(cellW, 0);
       }
       ctx.restore();
@@ -273,7 +273,7 @@ class Viz extends Component {
     const { treeX, treeY, cellH, levelOffset, path } = this.state;
     ctx.translate(treeX, treeY);
     for (let level = 0; level < path.length; level++) {
-      this.drawNode(ctx, level);
+      this.drawTreeNode(ctx, level);
       ctx.translate(0, cellH * levelOffset);
     }
     ctx.restore();

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -317,13 +317,18 @@ class Viz extends Component {
   };
   drawCalendarCell = (ctx, level, cell) => {
     const s = this.state.calCellSize;
+    const len = 5;
+    ctx.save();
     ctx.beginPath();
     ctx.moveTo(0, 0);
     ctx.lineTo(s, 0);
-    ctx.moveTo(0, s);
-    ctx.lineTo(s, s);
     ctx.stroke();
-    // ctx.strokeRect(0, 0, s, s);
+    ctx.globalAlpha *= 0.5;
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(0, len);
+    ctx.stroke();
+    ctx.restore();
   };
   drawCalendarNode = (ctx, level) => {
     const n = this.state.numSquareCells;
@@ -453,7 +458,7 @@ class Viz extends Component {
 
     // clip window
     ctx.beginPath();
-    ctx.rect(-1, -1, s * n + 2, s * n + 2);
+    ctx.rect(-1, -1, calW + 2, calW + 2);
     ctx.clip();
 
     const transformToChild = () => {
@@ -476,11 +481,25 @@ class Viz extends Component {
     this.drawCalendarNode(ctx, level);
     ctx.restore();
 
+    // draw parent ticks
+    ctx.save();
+    transformToParent();
+    this.drawCalendarNodeTicks(ctx, level);
+    ctx.strokeRect(0, 0, calW, calW);
+    ctx.restore();
+
     // draw child
+    const childAlpha = d3interpolate.interpolate(0, 1)(Math.pow(camT, 2));
     ctx.save();
     transformToChild();
-    ctx.globalAlpha *= d3interpolate.interpolate(0, 1)(Math.pow(camT, 2));
+    ctx.beginPath();
+    ctx.rect(-1, -1, calW + 2, calW + 2);
+    ctx.clip();
+    ctx.globalAlpha *= childAlpha;
+    ctx.fillStyle = "#fff";
+    ctx.fillRect(0, 0, calW, calW);
     this.drawCalendarNode(ctx, level + 1);
+    this.drawCalendarNodeTicks(ctx, level + 1);
     ctx.restore();
 
     // outline child
@@ -492,13 +511,7 @@ class Viz extends Component {
 
     // outline window
     ctx.strokeStyle = "#555";
-    ctx.strokeRect(0, 0, s * n, s * n);
-
-    // draw ticks
-    ctx.save();
-    transformToParent();
-    this.drawCalendarNodeTicks(ctx, level);
-    ctx.restore();
+    ctx.strokeRect(0, 0, calW, calW);
 
     ctx.restore();
   };

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -356,7 +356,7 @@ class Viz extends Component {
     ctx.translate(cellX * s, cellY * s);
     const scale2 = 1 / numSquareCells;
     ctx.lineWidth /= scale2;
-    ctx.globalAlpha *= t;
+    ctx.globalAlpha *= Math.pow(t, 2);
     ctx.scale(scale2, scale2);
     for (let cy = 0; cy < numSquareCells; cy++) {
       ctx.save();

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -317,7 +317,13 @@ class Viz extends Component {
   };
   drawCalendarCell = (ctx, level, cell) => {
     const s = this.state.calCellSize;
-    ctx.strokeRect(0, 0, s, s);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(s, 0);
+    ctx.moveTo(0, s);
+    ctx.lineTo(s, s);
+    ctx.stroke();
+    // ctx.strokeRect(0, 0, s, s);
   };
   drawCalendarNode = (ctx, level) => {
     const n = this.state.numSquareCells;
@@ -337,12 +343,12 @@ class Viz extends Component {
   };
   drawCalendarNodeTicks = (ctx, level) => {
     ctx.save();
+    ctx.lineWidth *= 2;
+    ctx.font = "10px sans-serif";
+    ctx.textBaseline = "top";
+    ctx.textAlign = "left";
     const { calTimeK, calKX, calKRow, calRowY } = this.ds;
     if (level === 0) {
-      ctx.lineWidth *= 2;
-      ctx.font = "10px sans-serif";
-      ctx.textBaseline = "top";
-      ctx.textAlign = "left";
       const drawTick = (t, color, title) => {
         const k = calTimeK[level](t);
         const x = calKX(k);
@@ -360,6 +366,35 @@ class Viz extends Component {
       };
       drawTick(0, "#1eb7aa", "unix\nepoch");
       drawTick(+new Date() * 1e6, "#db7b35", "now");
+    }
+
+    ctx.lineWidth /= 2;
+    ctx.strokeStyle = ctx.fillStyle = "rgba(90,110,100, 0.5)";
+    const drawTick = (t, title) => {
+      const k = calTimeK[level](t);
+      const x = calKX(k);
+      const row = calKRow(k);
+      ctx.beginPath();
+      ctx.moveTo(x, calRowY(row));
+      ctx.lineTo(x, calRowY(row + 1));
+      ctx.stroke();
+      let y = calRowY(row);
+      for (let text of title.split("\n")) {
+        ctx.fillText(text, x + 5, y + 2);
+        y += 12;
+      }
+    };
+    const count = 32;
+    const ticks = calTimeK[level].ticks(count);
+    const tickFormat = calTimeK[level].tickFormat(count);
+    for (let i = 0; i < ticks.length; i++) {
+      const tickTime = ticks[i];
+      if (ticks[i] === ticks[i - 1]) continue; // nanosecond ticks sometimes duplicate
+      if (level === 0 && i === 7) continue; // we already drew this as "unix epoch"
+      const text = tickFormat(tickTime)
+        .split(" ")
+        .join("\n");
+      drawTick(tickTime, text);
     }
     ctx.restore();
   };

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -249,8 +249,7 @@ class Viz extends Component {
       const drawTick = (t, color, title) => {
         const x = treeTimeX[level](t);
         if (x < 0 || x > treeColX(numCells)) return;
-        ctx.strokeStyle = color;
-        ctx.fillStyle = color;
+        ctx.fillStyle = ctx.strokeStyle = color;
         ctx.beginPath();
         ctx.moveTo(x, treeRowY(-0.7));
         ctx.lineTo(x, treeRowY(1));
@@ -341,19 +340,25 @@ class Viz extends Component {
     const { calTimeK, calKX, calKRow, calRowY } = this.ds;
     if (level === 0) {
       ctx.lineWidth *= 2;
+      ctx.font = "10px sans-serif";
+      ctx.textBaseline = "top";
+      ctx.textAlign = "left";
       const drawTick = (t, color, title) => {
         const k = calTimeK[level](t);
         const x = calKX(k);
         const row = calKRow(k);
-        ctx.strokeStyle = color;
-        ctx.fillStyle = color;
+        ctx.fillStyle = ctx.strokeStyle = color;
         ctx.beginPath();
         ctx.moveTo(x, calRowY(row));
         ctx.lineTo(x, calRowY(row + 1));
         ctx.stroke();
-        // ctx.fillText(title, x, treeRowY(-2));
+        let y = calRowY(row);
+        for (let text of title.split("\n")) {
+          ctx.fillText(text, x + 5, y + 2);
+          y += 12;
+        }
       };
-      drawTick(0, "#1eb7aa", "unix epoch");
+      drawTick(0, "#1eb7aa", "unix\nepoch");
       drawTick(+new Date() * 1e6, "#db7b35", "now");
     }
     ctx.restore();

--- a/src/Viz.js
+++ b/src/Viz.js
@@ -6,6 +6,20 @@ import * as d3interpolate from "d3-interpolate";
 // import * as d3transition from "d3-transition";
 // import * as d3shape from "d3-shape";
 
+const nodeLengthLabels = [
+  "146 years",
+  "2.28 years",
+  "13.03 days",
+  "4.88 hours",
+  "4.58 min",
+  "4.29 s",
+  "67.11 ms",
+  "1.05 ms",
+  "16.38 µs",
+  "256 ns",
+  "4 ns"
+];
+
 class Viz extends Component {
   constructor(props) {
     super(props);
@@ -28,7 +42,7 @@ class Viz extends Component {
       levelOffset: 5,
 
       // Calendar placement and sizing
-      calCellSize: 40,
+      calCellSize: 38,
       calX: 700,
       calY: 40,
 
@@ -287,20 +301,7 @@ class Viz extends Component {
     if (t === 1) {
       ctx.textAlign = "left";
       ctx.textBaseline = "middle";
-      const labels = [
-        "146 years",
-        "2.28 years",
-        "13.03 days",
-        "4.88 hours",
-        "4.58 min",
-        "4.29 s",
-        "67.11 ms",
-        "1.05 ms",
-        "16.38 µs",
-        "256 ns",
-        "4 ns"
-      ];
-      ctx.fillText(labels[level], x1 + 28, treeRowY(0.5));
+      ctx.fillText(nodeLengthLabels[level], x1 + 28, treeRowY(0.5));
     }
 
     ctx.restore();
@@ -413,7 +414,7 @@ class Viz extends Component {
       calX,
       calY
     } = this.state;
-    const { dipTime, calW } = this.ds;
+    const { dipTime, calW, calTimeK } = this.ds;
 
     const s = calCellSize;
     const n = numSquareCells;
@@ -435,10 +436,12 @@ class Viz extends Component {
       .clamp(true)(t);
 
     let index = Math.floor(pathAnim);
+    let contextLabelIndex = index - 1;
 
     // edge case for last path
     if (index > path.length - 1) {
       index = path.length - 1;
+      contextLabelIndex = index;
       camT = 1;
       highlightT = 1;
     }
@@ -456,6 +459,27 @@ class Viz extends Component {
 
     ctx.save();
     ctx.translate(calX, calY);
+
+    // draw date context
+    ctx.save();
+    ctx.translate(calW, 0);
+    ctx.textBaseline = "bottom";
+    ctx.textAlign = "right";
+    const contextDate = calTimeK[level].contextFormat();
+    if (contextDate) {
+      ctx.fillStyle = "rgba(90,110,100, 0.3)";
+      ctx.fillText(contextDate, 0, -10);
+    }
+    ctx.restore();
+
+    // draw node time length
+    ctx.save();
+    ctx.translate(calW, calW);
+    ctx.textBaseline = "top";
+    ctx.textAlign = "right";
+    ctx.fillStyle = "rgba(90,110,100, 0.5)";
+    ctx.fillText(nodeLengthLabels[contextLabelIndex], -5, 10);
+    ctx.restore();
 
     // clip window
     ctx.beginPath();


### PR DESCRIPTION
Having a branching factor of 64 lets us use 8x8 calendar to drive the zoom analogy, while keeping the original flat representation to track where we are in the tree.

Initially planned to explicitly show the 8x8 grid:

![calendar-zoom](https://user-images.githubusercontent.com/116838/34784961-5b419eb8-f5f5-11e7-928d-df6bd540eaf7.gif)

But due to date ticks misaligning with the 8x8 grid (creating a lot of visual disorder), I opted to draw vertical lines at the dates, and use smaller ticks for the grid:

![calendar-crop](https://user-images.githubusercontent.com/116838/34836588-f3cb9a3a-f6bd-11e7-8274-7fd588d1cd42.gif)
