### PR TITLE
Show mid-resolution blocks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,17 @@
+## v2018.01.28
+
+[screenshot][screenshot-2018-01-28] | [demo permalink][demo-2018-01-28]
+
+- Show mid-resolution cells (See [#5](https://github.com/PingThingsIO/btrdb-explained/pull/5))
+
+[screenshot-2018-01-28]:https://user-images.githubusercontent.com/116838/35482932-55640df4-0401-11e8-932a-da14fa03b7ae.gif
+[demo-2018-01-28]:http://btrdb-viz-2018-01-28.surge.sh
+
 ## v2018.01.22
 
 [screenshot][screenshot-2018-01-22] | [demo permalink][demo-2018-01-22]
 
-- Add mouse controls for exploring the tree
+- Add mouse controls for exploring the tree (See [#4](https://github.com/PingThingsIO/btrdb-explained/pull/4))
 
 [screenshot-2018-01-22]:https://user-images.githubusercontent.com/116838/35245661-a2e4ad26-ff89-11e7-83a2-4db239a4ed4a.gif
 [demo-2018-01-22]:http://btrdb-viz-2018-01-22.surge.sh
@@ -11,7 +20,7 @@
 
 [screenshot][screenshot-2018-01-11] | [demo permalink][demo-2018-01-11]
 
-- Add calendar metaphor for a zoomable 2D representation
+- Add calendar metaphor for a zoomable 2D representation (See [#3](https://github.com/PingThingsIO/btrdb-explained/pull/3))
 
 [screenshot-2018-01-11]:https://user-images.githubusercontent.com/116838/34836478-9ed6755e-f6bd-11e7-8895-353dfdfbc2cc.gif
 [demo-2018-01-11]:http://btrdb-viz-2018-01-11.surge.sh
@@ -20,7 +29,7 @@
 
 [screenshot][screenshot-2018-01-08] | [demo permalink][demo-2018-01-08]
 
-- Add date and time annotations
+- Add date and time annotations (See [#2](https://github.com/PingThingsIO/btrdb-explained/pull/2))
 
 [screenshot-2018-01-08]:https://user-images.githubusercontent.com/116838/34710929-d4f974e2-f4e2-11e7-8ccf-87fda093b2a5.gif
 [demo-2018-01-08]:http://btrdb-viz-2018-01-08.surge.sh/
@@ -29,7 +38,7 @@
 
 [screenshot][screenshot-2018-01-07] | [demo permalink][demo-2018-01-07]
 
-- Mouse up and down to show zooming into random nodes of the tree
+- Mouse up and down to show zooming into random nodes of the tree (See [#1](https://github.com/PingThingsIO/btrdb-explained/pull/1))
 
 [screenshot-2018-01-07]:https://user-images.githubusercontent.com/116838/34665780-2b68bb38-f427-11e7-96c1-95c80ed3f39c.gif
 [demo-2018-01-07]:http://btrdb-viz-2018-01-07.surge.sh/

--- a/src/Demo.js
+++ b/src/Demo.js
@@ -10,7 +10,7 @@ export default function() {
         <header>
           <img src={logo} className="Demo-logo" alt="PingThings" />
         </header>
-        <div className="Demo-version">{"BTrDB Viz v2018.01.22"}</div>
+        <div className="Demo-version">{"BTrDB Viz v2018.01.28"}</div>
         <div className="Demo-notes">
           <p>
             Zooming into a BTrDB tree is achieved by descending its branches, so
@@ -24,11 +24,11 @@ export default function() {
           </ul>
           <h3>Changes</h3>
           <ul>
-            <li>Mouse interactions</li>
+            <li>Mid-resolution cells</li>
           </ul>
           <h3>Next</h3>
           <ul>
-            <li>Show mid-levels</li>
+            <li>Correlate with Plotter</li>
           </ul>
         </div>
       </div>

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -56,10 +56,10 @@ class Tree extends Component {
 
       // Tree placement and sizing
       treeCellW: 8,
-      treeCellH: 12,
+      treeCellH: 10,
       treeX: 40,
       treeY: 34,
-      levelOffset: 5,
+      levelOffset: 7,
       cellHighlight: null,
 
       // Calendar placement and sizing
@@ -69,6 +69,14 @@ class Tree extends Component {
 
       rootStart: -1152921504606846976,
       rootResolution: 56
+
+      // TODO:
+      // selectionStart (path)
+      // selectionEnd (path)
+
+      // TODO:
+      // path has to allow mid-level resolution cells
+      // idea: mouseToPath returns {level, numCells}
     };
     for (let i = 1; i < 10; i++) {
       this.state.path.push(Math.floor(Math.random() * this.state.numCells));
@@ -270,6 +278,22 @@ class Tree extends Component {
       ctx.fill();
     }
 
+    // draw mid-resolution blocks (temporary)
+    if (level > 0 && t === 1) {
+      for (let i = 0; i < 6; i++) {
+        ctx.save();
+        const x = this.midResStart(parent, i) * treeCellW;
+        const y = (-levelOffset + 1 + i) * treeCellH;
+        ctx.translate(x, y);
+        const numMidCells = Math.pow(2, i);
+        for (let j = 0; j < numMidCells; j++) {
+          ctx.strokeRect(0, 0, treeCellW, treeCellH);
+          ctx.translate(treeCellW, 0);
+        }
+        ctx.restore();
+      }
+    }
+
     // Translate to the topleft corner of box
     ctx.translate(x0, y);
 
@@ -405,6 +429,16 @@ class Tree extends Component {
   };
   isCellExpanded = (level, cell) => {
     return this.state.path[level + 1] === cell;
+  };
+  midResStart = (parent, exp) => {
+    // 0 <= parent < 64   (the child node of previous level that we are expanding)
+    // 0 <= exp <= 6 (the resolution row => numMidCells = 2^exp)
+    const { numCells } = this.state;
+    const numMidCells = Math.pow(2, exp);
+    return d3scale
+      .scaleLinear()
+      .domain([0, numCells - 1])
+      .range([0, numCells - numMidCells])(parent);
   };
   mouseToPath = (x, y) => {
     const { treeX, treeY, treeCellW, treeCellH, levelOffset } = this.state;

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -269,25 +269,37 @@ class Tree extends Component {
     // Draw zooming cone that connects previous level to this one
     ctx.fillStyle = colors.zoomCone;
     if (level > 0 && t > dipTime) {
-      const ytop = scaleY(0) + treeCellH + 1;
+      ctx.save();
+      ctx.scale(treeCellW, treeCellH);
+      ctx.translate(0, -levelOffset + 1);
       ctx.beginPath();
-      ctx.moveTo(scaleX0(0), ytop);
-      ctx.lineTo(x0, y);
-      ctx.lineTo(x1, y);
-      ctx.lineTo(scaleX1(0), ytop);
+      const dy = 1 / treeCellH;
+      const maxy = d3scale
+        .scaleLinear()
+        .domain([dipTime, 1])
+        .range([0, levelOffset - 1])(t);
+      for (let y = 0; y < maxy; y += dy) {
+        const x = this.midResStart(parent, y);
+        y === 0 ? ctx.moveTo(x, y) : ctx.lineTo(x, y);
+      }
+      for (let y = maxy - dy; y >= 0; y -= dy) {
+        const x = this.midResStart(parent, y) + Math.pow(2, y);
+        ctx.lineTo(x, y);
+      }
       ctx.fill();
+      ctx.restore();
     }
 
     // draw mid-resolution blocks (temporary)
     if (level > 0 && t === 1) {
-      for (let i = 0; i < 6; i++) {
+      for (let i = 1; i < 6; i++) {
         ctx.save();
         const x = this.midResStart(parent, i) * treeCellW;
         const y = (-levelOffset + 1 + i) * treeCellH;
         ctx.translate(x, y);
         const numMidCells = Math.pow(2, i);
         for (let j = 0; j < numMidCells; j++) {
-          ctx.strokeRect(0, 0, treeCellW, treeCellH);
+          // ctx.strokeRect(0, 0, treeCellW, treeCellH);
           ctx.translate(treeCellW, 0);
         }
         ctx.restore();

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -281,30 +281,31 @@ class Tree extends Component {
       ctx.fill();
     }
 
-    // draw mid-resolution blocks (temporary)
-    if (level > 0 && t === 1) {
-      for (let r = 1; r < numMidRows; r++) {
-        ctx.save();
-        const { x, y, w, numCells } = this.cone(parent, r);
-        ctx.translate(Math.floor(x), y - treeCellH);
-        const midRes = r;
-        const show =
-          cellHighlight &&
-          cellHighlight.midRes === midRes &&
-          cellHighlight.level === level;
-        if (show) {
-          ctx.fillStyle = colors.midNodeFill;
-          ctx.fillRect(0, 0, w, treeCellH);
-          ctx.save();
-          for (let cell = 0; cell < numCells; cell++) {
-            this.drawTreeMidResCell(ctx, level, cell, midRes);
-            ctx.translate(treeCellW, 0);
-          }
-          ctx.restore();
-          ctx.strokeStyle = colors.midNodeStroke;
-          ctx.strokeRect(0, 0, w, treeCellH);
+    // Draw highlight cone
+    ctx.strokeStyle = ctx.fillStyle = colors.cellFillHighlight;
+    if (cellHighlight && cellHighlight.cell != null) {
+      const highlightAll =
+        cellHighlight.midRes == null &&
+        cellHighlight.level === level - 1 &&
+        cellHighlight.cell === parent;
+      const highlightOne =
+        cellHighlight.midRes != null && cellHighlight.level === level;
+      if (highlightAll || highlightOne) {
+        ctx.beginPath();
+        const dr = 1 / treeCellH;
+        const startR = highlightOne ? cellHighlight.midRes : 0;
+        const startCell = highlightOne ? cellHighlight.cell : 0;
+        const top = this.cone(parent, startR);
+        for (let r = startR; r < coneRow; r += dr) {
+          const { x, y, w } = this.cone(parent, r);
+          ctx.lineTo(x + w * startCell / top.numCells, y);
         }
-        ctx.restore();
+        for (let r = coneRow - dr; r >= startR; r -= dr) {
+          const { x, y, w } = this.cone(parent, r);
+          ctx.lineTo(x + w * (startCell + 1) / top.numCells, y);
+        }
+        ctx.fill();
+        ctx.stroke();
       }
     }
 
@@ -381,6 +382,34 @@ class Tree extends Component {
       ctx.textAlign = "left";
       ctx.textBaseline = "middle";
       ctx.fillText(nodeLengthLabels[level], x1 + 28, treeRowY(0.5));
+    }
+
+    // draw mid-resolution blocks
+    ctx.translate(-x, -y);
+    if (level > 0 && t === 1) {
+      for (let r = 1; r < numMidRows; r++) {
+        ctx.save();
+        const { x, y, w, numCells } = this.cone(parent, r);
+        ctx.translate(Math.floor(x), y - treeCellH);
+        const midRes = r;
+        const show =
+          cellHighlight &&
+          cellHighlight.midRes === midRes &&
+          cellHighlight.level === level;
+        if (show) {
+          ctx.fillStyle = colors.midNodeFill;
+          ctx.fillRect(0, 0, w, treeCellH);
+          ctx.save();
+          for (let cell = 0; cell < numCells; cell++) {
+            this.drawTreeMidResCell(ctx, level, cell, midRes);
+            ctx.translate(treeCellW, 0);
+          }
+          ctx.restore();
+          ctx.strokeStyle = colors.midNodeStroke;
+          ctx.strokeRect(0, 0, w, treeCellH);
+        }
+        ctx.restore();
+      }
     }
 
     ctx.restore();

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -231,39 +231,6 @@ class Tree extends Component {
     // do not draw if pathAnim has not reached our level
     if (t === 0) return;
 
-    const domain = [0, dipTime, 1];
-
-    // left side
-    const scaleX0 = d3scale
-      .scaleLinear()
-      .domain(domain)
-      .range([treeColX(parent), treeColX(parent), treeColX(0)])
-      .clamp(true);
-
-    // right side
-    const scaleX1 = d3scale
-      .scaleLinear()
-      .domain(domain)
-      .range([treeColX(parent + 1), treeColX(parent + 1), treeColX(numCells)])
-      .clamp(true);
-
-    // top side
-    const scaleY = d3scale
-      .scaleLinear()
-      .domain(domain)
-      .range([
-        treeRowY(-levelOffset),
-        treeRowY(-levelOffset * (1 - dipTime)),
-        treeRowY(0)
-      ])
-      .clamp(true);
-
-    // compute
-    const x0 = scaleX0(t);
-    const x1 = scaleX1(t);
-    const y = scaleY(t);
-    const w = x1 - x0;
-
     ctx.save();
 
     // Draw zooming cone that connects previous level to this one
@@ -305,6 +272,22 @@ class Tree extends Component {
         ctx.restore();
       }
     }
+
+    // compute
+    const midT = d3scale
+      .scaleLinear()
+      .domain([dipTime, 1])
+      .range([0, 1])(t);
+    if (t > 0 && t < 1) {
+      console.log(midT);
+    }
+    const x0 =
+      t < dipTime
+        ? treeColX(parent)
+        : this.midResStart(parent, midT * 6) * treeCellW;
+    const w = t < dipTime ? treeCellW : Math.pow(2, midT * 6) * treeCellW;
+    const x1 = x0 + w;
+    const y = d3interpolate.interpolate(treeRowY(-levelOffset), treeRowY(0))(t);
 
     // Translate to the topleft corner of box
     ctx.translate(x0, y);

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -271,7 +271,7 @@ class Tree extends Component {
         const { x, y, numCells } = cone(r);
         ctx.translate(x, y);
         for (let i = 0; i < numCells; i++) {
-          ctx.strokeRect(0, -treeCellH / 2, treeCellW, treeCellH);
+          ctx.strokeRect(0, -treeCellH, treeCellW, treeCellH);
           ctx.translate(treeCellW, 0);
         }
         ctx.restore();
@@ -430,16 +430,24 @@ class Tree extends Component {
   mouseToPath = (x, y) => {
     const { treeX, treeY, treeCellW, treeCellH, levelOffset } = this.state;
 
+    // if mouse between two levels, always return {level,midRow}
+    // if mouse inside midRow return {level,midRow,cell}
+
     const cell = Math.floor((x - treeX) / treeCellW);
     const gridY = Math.floor((y - treeY) / treeCellH);
     const level = Math.floor(gridY / levelOffset);
-    if (
+
+    const hoverLevel =
       cell >= 0 &&
       cell < 64 &&
       gridY % levelOffset === 0 &&
-      this.isLevelVisible(level)
-    ) {
+      this.isLevelVisible(level);
+    const hoverMidLevel =
+      gridY % levelOffset > 0 && this.isLevelVisible(level + 1);
+    if (hoverLevel) {
       return { level, cell };
+    } else if (hoverMidLevel) {
+      console.log(gridY);
     }
 
     // TODO: compute "derived" resolution cells

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -615,7 +615,11 @@ class Tree extends Component {
   onMouseUp = e => {
     this.mousedownLevel = null;
     const { cellHighlight, pathAnim } = this.state;
-    if (cellHighlight && cellHighlight.midRes == null) {
+    if (
+      cellHighlight &&
+      cellHighlight.midRes == null &&
+      this.levelClickable(cellHighlight.level)
+    ) {
       const { level, cell } = cellHighlight;
       const parentPath = this.state.path.slice(0, level + 1);
       if (this.isLevelVisible(level + 1)) {
@@ -643,6 +647,9 @@ class Tree extends Component {
       }
     }
   };
+  levelClickable = level => {
+    return level < 9;
+  };
   onMouseMove = e => {
     const { x, y } = this.getMousePos(e);
     if (this.state.scrubbing) {
@@ -651,8 +658,10 @@ class Tree extends Component {
       const curr = this.mouseToPath(x, y);
       const prev = this.state.cellHighlight;
       const cell = curr && curr.cell;
+      const level = curr && curr.level;
       const midRes = curr && curr.midRes;
-      const clickable = cell != null && midRes == null;
+      const clickable =
+        cell != null && midRes == null && this.levelClickable(level);
       this.setState({
         cursor: clickable ? "pointer" : "default"
       });


### PR DESCRIPTION
To show how statistical points are computed for resolutions between levels of the tree:

- [x] **appearing** - when mouse is between tree levels, highlight the intermediate row to show mid-resolution cells
- [x] **associating** - when hovering over a mid-resolution cell, highlight the cell _and_ all the corresponding cells in the level below it that it is computed from
- [x] **emphasizing** - the mid cells should be the same size as the real cells, but should be dimmer to emphasize that they are virtually computed rather than stored
- [x] The "zoom cone" can also now be replaced with a nicer exponential curve that fits our mid-resolution cells.

![highlight-cone](https://user-images.githubusercontent.com/116838/35482745-2cc91de6-03ff-11e8-87da-d7bdc66f53b8.gif)

