### PR TITLE
Populate Tree with Simplex Noise, and plot levels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## v2018.02.08
+
+[screenshot][screenshot-2018-02-08] | [demo permalink][demo-2018-02-08]
+
+- Populate tree with Simplex Noise and plot
+
+[screenshot-2018-02-08]:https://user-images.githubusercontent.com/116838/35985837-2b30fb54-0cbd-11e8-86f7-705ced580456.gif
+[demo-2018-02-08]:http://btrdb-viz-2018-02-08.surge.sh
+
 ## v2018.01.28
 
 [screenshot][screenshot-2018-01-28] | [demo permalink][demo-2018-01-28]

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "private": true,
   "dependencies": {
     "d3-array": "^1.2.1",
+    "d3-color": "^1.0.3",
     "d3-ease": "^1.0.3",
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.2.0",
     "d3-transition": "^1.1.1",
     "fast-simplex-noise": "^3.2.0",
-    "hex-to-rgba": "^1.0.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -3,14 +3,17 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "d3-array": "^1.2.1",
     "d3-ease": "^1.0.3",
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.2.0",
     "d3-transition": "^1.1.1",
+    "fast-simplex-noise": "^3.2.0",
     "hex-to-rgba": "^1.0.1",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
-    "react-scripts": "1.0.17"
+    "react-scripts": "1.0.17",
+    "seedrandom": "^2.4.3"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/Demo.js
+++ b/src/Demo.js
@@ -10,7 +10,7 @@ export default function() {
         <header>
           <img src={logo} className="Demo-logo" alt="PingThings" />
         </header>
-        <div className="Demo-version">{"BTrDB Viz v2018.01.28"}</div>
+        <div className="Demo-version">{"BTrDB Viz v2018.02.08"}</div>
         <div className="Demo-notes">
           <p>
             Zooming into a BTrDB tree is achieved by descending its branches, so
@@ -24,11 +24,12 @@ export default function() {
           </ul>
           <h3>Changes</h3>
           <ul>
-            <li>Mid-resolution cells</li>
+            <li>Populate w/ Noise</li>
+            <li>Draw Plot</li>
           </ul>
           <h3>Next</h3>
           <ul>
-            <li>Correlate with Plotter</li>
+            <li>Explanatory Annotations</li>
           </ul>
         </div>
       </div>

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -6,6 +6,7 @@ import * as d3ease from "d3-ease";
 import * as d3transition from "d3-transition";
 import hexToRgba from "hex-to-rgba";
 // import * as d3shape from "d3-shape";
+import "./datagen";
 
 const nodeLengthLabels = [
   "146 years",

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -5,7 +5,7 @@ import * as d3interpolate from "d3-interpolate";
 import * as d3ease from "d3-ease";
 import * as d3transition from "d3-transition";
 import * as d3array from "d3-array";
-import hexToRgba from "hex-to-rgba";
+import * as d3color from "d3-color";
 import * as d3shape from "d3-shape";
 import { getStatPoint } from "./datagen";
 
@@ -23,6 +23,12 @@ const nodeLengthLabels = [
   "4 ns"
 ];
 
+function rgba(color, opacity) {
+  const c = d3color.color(color);
+  c.opacity = opacity;
+  return c + "";
+}
+
 const theme = {
   green: "#1eb7aa",
   orange: "#db7b35"
@@ -30,15 +36,15 @@ const theme = {
 
 const colors = {
   cellFillExpanded: "rgba(80,100,120, 0.15)",
-  cellFillHighlight: hexToRgba(theme.green, 0.8),
-  cellWall: hexToRgba("#555", 0.1),
+  cellFillHighlight: rgba(theme.green, 0.8),
+  cellWall: rgba("#555", 0.1),
   cellWallExpanded: "#555",
   cellWallHighlight: theme.green,
 
   nodeFill: "#fff",
   nodeStroke: "#000",
-  midNodeFill: hexToRgba("#fff", 0.5),
-  midNodeStroke: hexToRgba("#000", 0.5),
+  midNodeFill: rgba("#fff", 0.5),
+  midNodeStroke: rgba("#000", 0.5),
 
   unixEpoch: theme.green,
   now: theme.orange,
@@ -46,10 +52,10 @@ const colors = {
   scrub: "#e7e8e9",
 
   zoomCone: "rgba(80,100,120, 0.15)",
-  shadowCone: hexToRgba(theme.green, 0.4),
+  shadowCone: rgba(theme.green, 0.4),
 
   plotShadow: "rgba(80,100,120, 0.15)",
-  plotLine: hexToRgba("#555", 0.5),
+  plotLine: rgba("#555", 0.5),
   plotBorder: "#555",
   plotHighlight: theme.green,
   clear: "rgba(0,0,0,0)"
@@ -425,7 +431,7 @@ class Tree extends Component {
           ctx.fillStyle = colors.shadowCone;
           ctx.fillRect(0, 0, treeCellW * blockSize, treeCellH);
         }
-        ctx.strokeStyle = hexToRgba("#555", 0.5);
+        ctx.strokeStyle = rgba("#555", 0.5);
         ctx.strokeRect(0, 0, treeCellW * blockSize, treeCellH);
         ctx.translate(blockSize * treeCellW, 0);
       }
@@ -530,7 +536,7 @@ class Tree extends Component {
     ctx.translate(plotX, treeCellH / 2 - plotH / 2);
 
     // draw border
-    ctx.fillStyle = colors.plotBorder;
+    ctx.strokeStyle = colors.plotBorder;
     ctx.strokeRect(0, 0, plotW, plotH);
 
     // draw min/max shadow

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -28,7 +28,7 @@ const theme = {
 
 const colors = {
   cellFillExpanded: "rgba(80,100,120, 0.15)",
-  cellFillHighlight: hexToRgba(theme.green, 0.4),
+  cellFillHighlight: hexToRgba(theme.green, 0.8),
   cellWall: hexToRgba("#555", 0.1),
   cellWallExpanded: "#555",
   cellWallHighlight: theme.green,
@@ -44,7 +44,7 @@ const colors = {
   scrub: "#e7e8e9",
 
   zoomCone: "rgba(80,100,120, 0.15)",
-  highlightCone: "rgba(80,100,120, 0.2)",
+  shadowCone: hexToRgba(theme.green, 0.4),
   clear: "rgba(0,0,0,0)"
 };
 
@@ -313,7 +313,7 @@ class Tree extends Component {
         const { x, y, w } = this.cone(parent, r);
         ctx.lineTo(x + w * (startCell + 1) / top.numCells, y);
       }
-      ctx.fillStyle = colors.cellFillHighlight;
+      ctx.fillStyle = colors.shadowCone;
       ctx.fill();
     }
   };
@@ -390,7 +390,7 @@ class Tree extends Component {
       ctx.save();
       for (let cell = 0; cell < numCells; cell += blockSize) {
         if (cell === cellHighlight.cell * blockSize) {
-          ctx.fillStyle = colors.cellFillHighlight;
+          ctx.fillStyle = colors.shadowCone;
           ctx.fillRect(0, 0, treeCellW * blockSize, treeCellH);
         }
         ctx.strokeStyle = hexToRgba("#555", 0.5);

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -652,17 +652,15 @@ class Tree extends Component {
           );
       }
     }
+    this.onMouseMove();
   };
   levelClickable = level => {
     return level < 9;
   };
   cellClickable = obj => {
-    const cell = obj && obj.cell;
-    const level = obj && obj.level;
-    const midRes = obj && obj.midRes;
-    const clickable =
-      cell != null && midRes == null && this.levelClickable(level);
-    return clickable;
+    if (!obj) return false;
+    const { cell, level, midRes } = obj;
+    return cell != null && midRes == null && this.levelClickable(level);
   };
   onMouseMove = e => {
     const mouse = this.getMousePos(e);

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -162,29 +162,24 @@ function fitChildren(points, parent) {
   return fitPoints;
 }
 
-function computeChildren(cache, parentPath) {
-  if (!parentPath) return;
-  const points = d3array.range(64).map(i => getNoise([...parentPath, i]));
-  const parent = getStatPoint(cache, parentPath);
-  const finalPoints = parent ? fitChildren(points, parent) : points;
-  cacheWrite(cache, parentPath, finalPoints);
-}
-
 // path = tree node path from root
 function getStatPoint(cache, path) {
   if (!path || !path.length) return;
 
-  const point = cacheLookup(cache, path);
-  if (point) return point;
-
-  const parentPath = path.slice(0, -1);
-  computeChildren(cache, parentPath);
-  const value = cacheLookup(cache, path);
-  return value;
+  let point = cacheLookup(cache, path);
+  if (!point || !point.children) {
+    const parentPath = path.slice(0, -1);
+    const points = d3array.range(64).map(i => getNoise([...parentPath, i]));
+    const parent = getStatPoint(cache, parentPath);
+    const fitPoints = parent ? fitChildren(points, parent) : points;
+    cacheWrite(cache, parentPath, fitPoints);
+    point = cacheLookup(cache, path);
+  }
+  return point;
 }
 
 function test() {
-  const cache = { children: [] };
+  const cache = {};
   getStatPoint(cache, [0, 1, 2]);
   console.log(cache);
 }

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -12,14 +12,15 @@ const globalCache = {};
 // prettier-ignore
 const levelNoiseKnobs = [
   {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
-  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.111, shadowFrequency: 0.05, octaves: 2, persistence: 0.5, meanHeight: 43, shadowHeight: 57},
+  {meanFrequency: 0.24, shadowFrequency: 0.049, octaves: 4, persistence: 0.5, meanHeight: 28, shadowHeight: 19},
+  {meanFrequency: 0.078, shadowFrequency: 0.049, octaves: 5, persistence: 0.5, meanHeight: 72, shadowHeight: 39},
+  {meanFrequency: 0.363, shadowFrequency: 0.042, octaves: 1, persistence: 0.5, meanHeight: 72, shadowHeight: 74},
+  {meanFrequency: 0.095, shadowFrequency: 0.05, octaves: 3, persistence: 0.5, meanHeight: 140, shadowHeight: 74},
+  {meanFrequency: 0.053, shadowFrequency: 0.026, octaves: 2, persistence: 0.5, meanHeight: 140, shadowHeight: 87},
+  {meanFrequency: 0.029, shadowFrequency: 0.021, octaves: 3, persistence: 0.5, meanHeight: 90, shadowHeight: 46},
+  {meanFrequency: 0.021, shadowFrequency: 0.016, octaves: 2, persistence: 0.5, meanHeight: 70, shadowHeight: 46},
+
   {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
 ];
 
@@ -57,23 +58,23 @@ for (let {
 }
 
 // global noise knobs
-const meanNoiseTime = 0;
+const meanNoiseTime = 32;
 const minNoiseTime = 50;
 const maxNoiseTime = 80;
 
 function getNoiseXFromPath(path) {
-  let exp = 40; // some large exponent (maybe not the full 56 since too large for floats)
+  let exp = 0;
   let x = 0;
-  for (let p of path) {
-    x += p * 2 ** exp;
-    exp -= 6;
+  for (let i = path.length - 1; i >= 0; i--) {
+    x += path[i] * 2 ** exp;
+    exp += 6;
   }
   return x;
 }
 
 function getNoise(path) {
   const level = path.length - 1;
-  const x = getNoiseXFromPath(path);
+  const x = path.length === 1 ? path[0] : getNoiseXFromPath(path);
   const mean = meanNoise[level].scaled([x, meanNoiseTime]);
   const min = mean - shadowNoise[level].scaled([x, minNoiseTime]);
   const max = mean + shadowNoise[level].scaled([x, maxNoiseTime]);

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -94,6 +94,7 @@ function copyStat({ min, mean, max }) {
 }
 
 function midResChildren(children, res) {
+  if (!res) return;
   const numPoints = 2 ** res;
   const width = 64 / numPoints;
   const midResPoint = i => {

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -4,34 +4,83 @@ import * as d3array from "d3-array";
 
 // 10 levels of noise
 // TODO: create
-// reference: https://beta.observablehq.com/d/3194dc0ab478ec1c
+// reference: https://beta.observablehq.com/@shaunlebron/btrdb-mock-data-generator/2
+
+// level noise knobs
+// prettier-ignore
+const levelNoiseKnobs = [
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+  {meanFrequency: 0.03, shadowFrequency: 0.05, octaves: 5, persistence: 0.5, meanHeight: 120, shadowHeight: 40},
+];
+
 const meanNoise = [];
 const shadowNoise = [];
+for (let {
+  meanFrequency,
+  shadowFrequency,
+  octaves,
+  persistence,
+  meanHeight,
+  shadowHeight
+} of levelNoiseKnobs) {
+  const min = 0;
+  meanNoise.push(
+    new FastSimplexNoise({
+      random: seedrandom("hello"),
+      frequency: meanFrequency,
+      max: meanHeight,
+      persistence,
+      octaves,
+      min
+    })
+  );
+  shadowNoise.push(
+    new FastSimplexNoise({
+      random: seedrandom("hello"),
+      frequency: shadowFrequency,
+      max: shadowHeight,
+      persistence,
+      octaves,
+      min
+    })
+  );
+}
 
-const meanKnob = 0;
-const minKnob = 50;
-const maxKnob = 80;
+// global noise knobs
+const meanNoiseTime = 0;
+const minNoiseTime = 50;
+const maxNoiseTime = 80;
 
 function getNoiseXFromPath(path) {
-  const exp = 40; // some large exponent (maybe not the full 56 since too large for floats)
+  let exp = 40; // some large exponent (maybe not the full 56 since too large for floats)
   let x = 0;
   for (let p of path) {
     x += p * 2 ** exp;
     exp -= 6;
   }
+  return x;
 }
 
 function getNoise(path) {
   const level = path.length - 1;
   const x = getNoiseXFromPath(path);
-  const mean = meanNoise[level]([x, meanKnob]);
-  const min = mean - shadowNoise[level]([x, minKnob]);
-  const max = mean + shadowNoise[level]([x, maxKnob]);
+  const mean = meanNoise[level].scaled([x, meanNoiseTime]);
+  const min = mean - shadowNoise[level].scaled([x, minNoiseTime]);
+  const max = mean + shadowNoise[level].scaled([x, maxNoiseTime]);
   // TODO: add count
   return { mean, min, max };
 }
 
 function cacheLookup(cache, path) {
+  if (!path || !path.length) return;
   let curr = cache;
   for (let i of path) {
     if (!curr || !curr.children) return;
@@ -44,10 +93,27 @@ function copyStat({ min, mean, max }) {
   return { min, mean, max };
 }
 
+function midResChildren(children, res) {
+  const numPoints = 2 ** res;
+  const width = 64 / numPoints;
+  const midResPoint = i => {
+    const points = children.slice(i * width, (i + 1) * width);
+    return {
+      min: d3array.min(points, p => p.min),
+      max: d3array.max(points, p => p.max),
+      mean: d3array.sum(points, p => p.mean) / points.length
+    };
+  };
+  return d3array.range(numPoints).map(midResPoint);
+}
+
 function cacheWrite(cache, path, children) {
   let curr = cache;
   for (let i of path) curr = curr.children[i];
   curr.children = children.map(copyStat);
+  curr.midResChildren = d3array
+    .range(6)
+    .map(res => midResChildren(children, res));
 }
 
 function fitChildren(points, parent) {
@@ -64,8 +130,8 @@ function fitChildren(points, parent) {
   // Get local relative extremes.
   const localRelMin = d3array.min(relative, p => p.min);
   const localRelMax = d3array.max(relative, p => p.max);
-  const indexOfMin = relative.indexOf(localRelMin);
-  const indexOfMax = relative.indexOf(localRelMax);
+  const indexOfMin = relative.findIndex(p => p.min === localRelMin);
+  const indexOfMax = relative.findIndex(p => p.max === localRelMax);
 
   // Get global relative extremes that we must target.
   const globalRelMin = parent.min - parent.mean;
@@ -96,13 +162,12 @@ function fitChildren(points, parent) {
   return fitPoints;
 }
 
-function computeChildren(cache, path) {
-  if (!path || !path.length) return;
-  const points = d3array.range(64).map(i => getNoise([...path, i]));
-  const parentPath = path.slice(0, -1);
-  const parent = getStatPoint(parentPath);
-  fitChildren(points, parent);
-  cacheWrite(cache, parentPath, points);
+function computeChildren(cache, parentPath) {
+  if (!parentPath) return;
+  const points = d3array.range(64).map(i => getNoise([...parentPath, i]));
+  const parent = getStatPoint(cache, parentPath);
+  const finalPoints = parent ? fitChildren(points, parent) : points;
+  cacheWrite(cache, parentPath, finalPoints);
 }
 
 // path = tree node path from root
@@ -114,21 +179,15 @@ function getStatPoint(cache, path) {
 
   const parentPath = path.slice(0, -1);
   computeChildren(cache, parentPath);
-  return cacheLookup(cache, path);
+  const value = cacheLookup(cache, path);
+  return value;
 }
 
-function getMidStatPoint(cache, path, { res, cell }) {
-  const point = getStatPoint(cache, path);
-  if (!point) return;
-
-  if (!point.children) computeChildren(cache, path);
-
-  const width = 64 / 2 ** res;
-  const points = point.children.slice(cell * width, (cell + 1) * width);
-
-  return {
-    min: d3array.min(points, p => p.min),
-    max: d3array.max(points, p => p.max),
-    mean: d3array.sum(points, p => p.mean) / points.length
-  };
+function test() {
+  const cache = { children: [] };
+  getStatPoint(cache, [0, 1, 2]);
+  console.log(cache);
 }
+test();
+
+export { getStatPoint };

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -1,0 +1,118 @@
+import FastSimplexNoise from "fast-simplex-noise";
+import seedrandom from "seedrandom";
+import * as d3array from "d3-array";
+
+// 10 levels of noise
+// TODO: create
+// reference: https://beta.observablehq.com/d/3194dc0ab478ec1c
+const meanNoise = [];
+const shadowNoise = [];
+
+const meanKnob = 0;
+const minKnob = 50;
+const maxKnob = 80;
+
+function getNoiseXFromPath(path) {
+  const exp = 40; // some large exponent (maybe not the full 56 since too large for floats)
+  let x = 0;
+  for (let p of path) {
+    x += p * 2 ** exp;
+    exp -= 6;
+  }
+}
+
+function getNoise(path) {
+  const level = path.length - 1;
+  const x = getNoiseXFromPath(path);
+  const mean = meanNoise[level]([x, meanKnob]);
+  const min = mean - shadowNoise[level]([x, minKnob]);
+  const max = mean + shadowNoise[level]([x, maxKnob]);
+  // TODO: add count
+  return { mean, min, max };
+}
+
+function cacheLookup(cache, path) {
+  let curr = cache;
+  for (let i of path) {
+    if (!curr || !curr.children) return;
+    curr = curr.children[i];
+  }
+  if (curr) return curr.value;
+}
+
+function cacheWrite(cache, path, children) {
+  let curr = cache;
+  for (let i of path) curr = curr.children[i];
+  curr.children = children.map(value => ({ value }));
+}
+
+function fitChildren(points, parent) {
+  // Get mean-centered points.
+  // NOTE: disregarding count currently
+  const localMean = d3array.sum(points, p => p.mean) / points.length;
+  const center = localMean;
+  const relative = points.map(({ min, mean, max }) => ({
+    mean: mean - center,
+    min: min - center,
+    max: max - center
+  }));
+
+  // Get local relative extremes.
+  const localRelMin = d3array.min(relative, p => p.min);
+  const localRelMax = d3array.max(relative, p => p.max);
+  const indexOfMin = relative.indexOf(localRelMin);
+  const indexOfMax = relative.indexOf(localRelMax);
+
+  // Get global relative extremes that we must target.
+  const globalRelMin = parent.min - parent.mean;
+  const globalRelMax = parent.max - parent.mean;
+
+  // Get the minimum scale that we must stretch the local points such that
+  // they are contained inside the global bounds.
+  const fit = k =>
+    globalRelMin <= localRelMin * k && localRelMax * k <= globalRelMax;
+  const minStretch = globalRelMin / localRelMin;
+  const maxStretch = globalRelMax / localRelMax;
+  const stretch = fit(minStretch) ? minStretch : maxStretch;
+
+  // Fit points to target bounds as best we can w/ recentering and uniform scaling.
+  const fitPoint = (rel, k) => ({
+    mean: parent.mean + rel.mean * k,
+    min: parent.mean + rel.min * k,
+    max: parent.mean + rel.max * k
+  });
+  const fitPoints = relative.map(rel => fitPoint(rel, stretch));
+
+  // Since we are only guaranteed _one_ local bound is flushed against the
+  // global bounds, we stretch the two min and max points to the bounds manually
+  // to ensure to ensure both bounds are equal.
+  fitPoints[indexOfMin].min = parent.min;
+  fitPoints[indexOfMax].max = parent.max;
+
+  return fitPoints;
+}
+
+function computeChildren(path, cache) {
+  if (!path || !path.length) return;
+  const points = d3array.range(64).map(i => getNoise([...path, i]));
+  const parentPath = path.slice(0, -1);
+  const parent = getStatPoint(parentPath);
+  fitChildren(points, parent);
+  cacheWrite(cache, parentPath, points);
+}
+
+// path = tree node path from root
+function getStatPoint(path, mid, cache) {
+  if (!path || !path.length) return;
+
+  let point = cacheLookup(cache, path);
+  if (!point) {
+    computeChildren(path.slice(0, -1), cache);
+    point = cacheLookup(cache, path);
+  }
+
+  if (!mid) return point;
+
+  computeChildren(path, cache);
+  // TODO: aggregate points inside mid then return aggregate point
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1696,7 +1696,7 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-d3-array@^1.2.0:
+d3-array@^1.2.0, d3-array@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.1.tgz#d1ca33de2f6ac31efadb8e050a021d7e2396d5dc"
 
@@ -2502,6 +2502,10 @@ fast-json-stable-stringify@^2.0.0:
 fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+
+fast-simplex-noise@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/fast-simplex-noise/-/fast-simplex-noise-3.2.0.tgz#ae0b3cd7b9c2a056ecc72c2f7440cf7d0e3bca96"
 
 fastparse@^1.1.1:
   version "1.1.1"
@@ -5539,6 +5543,10 @@ schema-utils@^0.3.0:
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.3.0.tgz#f5877222ce3e931edae039f17eb3716e7137f8cf"
   dependencies:
     ajv "^5.0.0"
+
+seedrandom@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-2.4.3.tgz#2438504dad33917314bff18ac4d794f16d6aaecc"
 
 select-hose@^2.0.0:
   version "2.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1704,7 +1704,7 @@ d3-collection@1:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.4.tgz#342dfd12837c90974f33f1cc0a785aea570dcdc2"
 
-d3-color@1:
+d3-color@1, d3-color@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.0.3.tgz#bc7643fca8e53a8347e2fbdaffa236796b58509b"
 
@@ -2951,10 +2951,6 @@ hawk@3.1.3, hawk@~3.1.3:
 he@1.1.x:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
-
-hex-to-rgba@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/hex-to-rgba/-/hex-to-rgba-1.0.1.tgz#81adf8306207d659286cf80d71a9b5245c9c6cbe"
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
_Try live here: http://btrdb-viz-2018-02-08.surge.sh/_

To give the appearance of a fully populated BTrDB tree, we use a deterministic, random-seeded Simplex Noise function for each level (each with its own attributes).  Each node of 64 cells is made to fit its parent stats to create valid data for the BTrDB tree.

Next, we will annotate what the data plots mean, and correlate better with the mid-resolution cells.

![screenshot-2018-02-08](https://user-images.githubusercontent.com/116838/35985837-2b30fb54-0cbd-11e8-86f7-705ced580456.gif)
