### PR TITLE
Replace line plots with bounding boxes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+## v2018.03.19
+
+[demo permalink][demo-2018-03-19]
+
+- Replace line plots with bounding box plots, to clarify mid-res cell relationships
+
+[demo-2018-03-19]:http://btrdb-viz-2018-03-19.surge.sh
+
 ## v2018.02.08
 
 [screenshot][screenshot-2018-02-08] | [demo permalink][demo-2018-02-08]

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "d3-shape": "^1.2.0",
     "d3-transition": "^1.1.1",
     "fast-simplex-noise": "^3.2.0",
+    "ramda": "^0.25.0",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-scripts": "1.0.17",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "d3-array": "^1.2.1",
     "d3-color": "^1.0.3",
     "d3-ease": "^1.0.3",
+    "d3-interpolate": "^1.1.6",
     "d3-scale": "^1.0.7",
     "d3-shape": "^1.2.0",
     "d3-transition": "^1.1.1",

--- a/src/Demo.css
+++ b/src/Demo.css
@@ -54,6 +54,5 @@
 }
 
 .Demo-body {
-  padding-left: 48px;
-  padding-top: 48px;
+  padding: 0;
 }

--- a/src/Demo.js
+++ b/src/Demo.js
@@ -10,7 +10,7 @@ export default function() {
         <header>
           <img src={logo} className="Demo-logo" alt="PingThings" />
         </header>
-        <div className="Demo-version">{"BTrDB Viz v2018.02.08"}</div>
+        <div className="Demo-version">{"BTrDB Viz v2018.03.19"}</div>
         <div className="Demo-notes">
           <p>
             Zooming into a BTrDB tree is achieved by descending its branches, so
@@ -24,8 +24,7 @@ export default function() {
           </ul>
           <h3>Changes</h3>
           <ul>
-            <li>Populate w/ Noise</li>
-            <li>Draw Plot</li>
+            <li>Replace plot with bounding boxes</li>
           </ul>
           <h3>Next</h3>
           <ul>

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -103,6 +103,10 @@ const rightOfPath = path => {
   }
 };
 
+const padded = array => {
+  return array[-1] ? R.prepend(array[-1], array) : array;
+};
+
 class Tree extends Component {
   constructor(props) {
     super(props);
@@ -603,20 +607,15 @@ class Tree extends Component {
       cellHighlight.midRes != null
         ? cellHighlight.midRes
         : null;
-    const rawPoints = data.midResChildren[midRes] || data.children;
-    const points = rawPoints.map(({ min, mean, max }, i) => ({
-      min,
-      mean,
-      max,
-      i
-    }));
+    const points = data.midResChildren[midRes] || data.children;
+    const numPoints = midRes == null ? 64 : 2 ** midRes;
 
     if (!points) return;
 
     // scales
     const xScale = d3scale
       .scaleLinear()
-      .domain([-0.5, points.length - 0.5])
+      .domain([-0.5, numPoints - 0.5])
       .range([0, plotW]);
     const yScale = levelScaleY[level];
 
@@ -640,17 +639,24 @@ class Tree extends Component {
     ctx.strokeStyle = colors.plotBorder;
     ctx.strokeRect(0, 0, plotW, plotH);
 
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(0, 0, plotW, plotH);
+    ctx.clip();
+
     // draw min/max shadow
     ctx.beginPath();
-    shadow(points);
+    shadow(padded(points));
     ctx.fillStyle = colors.plotShadow;
     ctx.fill();
 
     // draw mean
     ctx.beginPath();
-    line(points);
+    line(padded(points));
     ctx.strokeStyle = colors.plotLine;
     ctx.stroke();
+
+    ctx.restore();
 
     const cellRect = ({ i, min, max }, res) => {
       // custom scale if we use lower resolution

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -508,7 +508,15 @@ class Tree extends Component {
     const { levelData, levelScaleY } = this.ds;
 
     // TODO: use midResChildren if highlighting midRes level
-    const points = levelData[level].children.map(({ min, mean, max }, i) => ({
+    const data = levelData[level];
+    const midRes =
+      cellHighlight &&
+      cellHighlight.level === level &&
+      cellHighlight.midRes != null
+        ? cellHighlight.midRes
+        : null;
+    const rawPoints = data.midResChildren[midRes] || data.children;
+    const points = rawPoints.map(({ min, mean, max }, i) => ({
       min,
       mean,
       max,
@@ -567,7 +575,7 @@ class Tree extends Component {
 
     // draw expanded cell
     const expandedCell = path[level + 1];
-    if (expandedCell != null) {
+    if (midRes == null && expandedCell != null) {
       const p = points[expandedCell];
       ctx.beginPath();
       cellRect(p);

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -78,8 +78,8 @@ class Tree extends Component {
       // Tree placement and sizing
       treeCellW: 8,
       treeCellH: 10,
-      treeX: 40,
-      treeY: 34,
+      treeX: 88,
+      treeY: 82,
       levelOffset: 7,
       cellHighlight: null,
 

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -564,13 +564,17 @@ class Tree extends Component {
     ctx.strokeStyle = colors.plotLine;
     ctx.stroke();
 
-    const cellRect = ({ i, min, max }) => {
-      ctx.rect(
-        xScale(i - 0.5),
-        yScale(min),
-        xScale(1) - xScale(0),
-        yScale(max) - yScale(min)
-      );
+    const cellRect = ({ i, min, max }, res) => {
+      // custom scale if we use lower resolution
+      const xs =
+        res == null
+          ? xScale
+          : d3scale
+              .scaleLinear()
+              .domain([-0.5, 2 ** res - 0.5])
+              .range([0, plotW]);
+      const ys = yScale;
+      ctx.rect(xs(i - 0.5), ys(min), xs(1) - xs(0), ys(max) - ys(min));
     };
 
     // draw expanded cell
@@ -614,12 +618,12 @@ class Tree extends Component {
     // draw highlighted cell
     if (
       cellHighlight &&
-      cellHighlight.midRes == null &&
-      cellHighlight.level === level
+      cellHighlight.level === level &&
+      cellHighlight.cell != null
     ) {
       const p = points[cellHighlight.cell];
       ctx.beginPath();
-      cellRect(p);
+      cellRect(p, cellHighlight.midRes);
       ctx.strokeStyle = colors.cellWallHighlight;
       ctx.stroke();
       ctx.fillStyle = colors.cellFillHighlight;

--- a/src/Tree.js
+++ b/src/Tree.js
@@ -62,6 +62,46 @@ const colors = {
   clear: "rgba(0,0,0,0)"
 };
 
+const leftOfPath = path => {
+  if (!path || !path.length) return;
+
+  const i = path[path.length - 1];
+  if (i > 0) {
+    const sibling = path.slice(0);
+    sibling.pop();
+    sibling.push(i - 1);
+    return sibling;
+  }
+
+  const parent = path.slice(0, path.length - 1);
+  const newParent = leftOfPath(parent);
+  if (newParent) {
+    const cousin = newParent.slice(0);
+    cousin.push(63);
+    return cousin;
+  }
+};
+
+const rightOfPath = path => {
+  if (!path || !path.length) return;
+
+  const i = path[path.length - 1];
+  if (i < 63) {
+    const sibling = path.slice(0);
+    sibling.pop();
+    sibling.push(i + 1);
+    return sibling;
+  }
+
+  const parent = path.slice(0, path.length - 1);
+  const newParent = rightOfPath(parent);
+  if (newParent) {
+    const cousin = newParent.slice(0);
+    cousin.push(0);
+    return cousin;
+  }
+};
+
 class Tree extends Component {
   constructor(props) {
     super(props);

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -212,7 +212,7 @@ function getStatPoint(path, cache) {
   if (path.length === 0) return cache;
 
   let point = cacheLookup(cache, path);
-  if (!point || !point.children) {
+  if (!point) {
     const parentPath = path.slice(0, -1);
     const points = d3array.range(64).map(i => getNoise([...parentPath, i]));
     const parent = getStatPoint(parentPath, cache);

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -150,11 +150,20 @@ function fitChildren(points, parent) {
 
   // Get the minimum scale that we must stretch the local points such that
   // they are contained inside the global bounds.
-  const fit = k =>
-    globalRelMin <= localRelMin * k && localRelMax * k <= globalRelMax;
   const minStretch = globalRelMin / localRelMin;
   const maxStretch = globalRelMax / localRelMax;
-  const stretch = fit(minStretch) ? minStretch : maxStretch;
+  const minFitDelta = globalRelMax - localRelMax * minStretch;
+  const maxFitDelta = localRelMin * maxStretch - globalRelMin;
+  const stretch =
+    minFitDelta >= 0
+      ? minStretch
+      : maxFitDelta >= 0
+        ? maxStretch
+        : // floating point precision errors can cause slight overshoots, so choose
+          // the one with the smallest delta.
+          Math.abs(minFitDelta) < Math.abs(maxFitDelta)
+          ? minStretch
+          : maxStretch;
 
   // Fit points to target bounds as best we can w/ recentering and uniform scaling.
   const fitPoint = (rel, k) => ({

--- a/src/datagen.js
+++ b/src/datagen.js
@@ -65,7 +65,12 @@ const maxNoiseTime = 80;
 function getNoiseXFromPath(path) {
   let exp = 0;
   let x = 0;
-  for (let i = path.length - 1; i >= 0; i--) {
+
+  // We can't go back further than 8 levels to compute x since floating points
+  // can't support numbers that high.
+  const rootI = Math.max(0, path.length - 8);
+
+  for (let i = path.length - 1; i >= rootI; i--) {
     x += path[i] * 2 ** exp;
     exp += 6;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5074,6 +5074,10 @@ raf@3.4.0:
   dependencies:
     performance-now "^2.1.0"
 
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1720,7 +1720,7 @@ d3-format@1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.2.1.tgz#4e19ecdb081a341dafaf5f555ee956bcfdbf167f"
 
-d3-interpolate@1:
+d3-interpolate@1, d3-interpolate@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.1.6.tgz#2cf395ae2381804df08aa1bf766b7f97b5f68fb6"
   dependencies:


### PR DESCRIPTION
Committing this [intermediate result](https://github.com/PingThingsIO/btrdb-explained/issues/11#issuecomment-368069578) that I never published:

_Live: http://btrdb-viz-2018-03-19.surge.sh/_

![](https://user-images.githubusercontent.com/116838/36606000-fc702232-1887-11e8-9b67-e1d81a8b2766.gif)

This should clarify how the mid-resolution cells relate to one another.  You can see how they are contained with the bounding boxes of the higher resolution cells.